### PR TITLE
SMC-153: Deploy ERC20-Wrapper-Gluwacoin (USDC-G) contract on Goerli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,13 @@ secret
 coverage.json
 .openzeppelin/unknown-*.json
 infuraAPI
+.env.development
+node_modules
+.env
+coverage
+coverage.json
+typechain
+
+#Hardhat files
+cache
+artifacts

--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -1,0 +1,403 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x649F87cac8AD7eA1829c3eB24eFbdB423dC002E6",
+    "txHash": "0x56fe1ae70d854d3cd098ef1bde1aeb8aef4127de189e0a44730ac54c3b198cf7"
+  },
+  "proxies": [
+    {
+      "address": "0x000CC169848eC63466A7EfB59e1b925ABAb5F92b",
+      "txHash": "0x22d91163afe8f0d6ce4b2472e4cd9514d35711c02a71369e475a5e6fddaa9baa",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "bdf43b6cea3091701e4c935220571baa94884fa93e2a0ffb790121f5c9f126a8": {
+      "address": "0x1dD7ab151fcFEE29Cc615df949D1d0CB407C2BD6",
+      "txHash": "0xcb2c2be635daeba4fc7e88bd6bda1162b8f13664b4f8f2ae575ea9a53157a692",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)179_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:247"
+          },
+          {
+            "label": "_roleMembers",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)3340_storage)",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlEnumerableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:37"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:394"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(IERC20Upgradeable)1524",
+            "contract": "ERC20Wrapper",
+            "src": "contracts\\abstracts\\ERC20Wrapper.sol:24"
+          },
+          {
+            "label": "_usedNonces",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))",
+            "contract": "ERC20Wrapper",
+            "src": "contracts\\abstracts\\ERC20Wrapper.sol:26"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20Wrapper",
+            "src": "contracts\\abstracts\\ERC20Wrapper.sol:221"
+          },
+          {
+            "label": "_usedNonces",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))",
+            "contract": "ERC20ETHless",
+            "src": "contracts\\abstracts\\ERC20ETHlessTransfer.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20ETHless",
+            "src": "contracts\\abstracts\\ERC20ETHlessTransfer.sol:111"
+          },
+          {
+            "label": "_reserved",
+            "offset": 0,
+            "slot": "354",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Reservation)4013_storage))",
+            "contract": "ERC20Reservable",
+            "src": "contracts\\abstracts\\ERC20Reservable.sol:35"
+          },
+          {
+            "label": "_totalReserved",
+            "offset": 0,
+            "slot": "355",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Reservable",
+            "src": "contracts\\abstracts\\ERC20Reservable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "356",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20Reservable",
+            "src": "contracts\\abstracts\\ERC20Reservable.sol:277"
+          },
+          {
+            "label": "_decimals",
+            "offset": 0,
+            "slot": "406",
+            "type": "t_uint8",
+            "contract": "ERC20WrapperGluwacoin",
+            "src": "contracts\\ERC20WrapperGluwacoin.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "407",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20WrapperGluwacoin",
+            "src": "contracts\\ERC20WrapperGluwacoin.sol:75"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20Upgradeable)1524": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ReservationStatus)3999": {
+            "label": "enum ERC20Reservable.ReservationStatus",
+            "members": [
+              "Draft",
+              "Active",
+              "Reclaimed",
+              "Completed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_bool))": {
+            "label": "mapping(address => mapping(uint256 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Reservation)4013_storage))": {
+            "label": "mapping(address => mapping(uint256 => struct ERC20Reservable.Reservation))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)3340_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)179_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bool)": {
+            "label": "mapping(uint256 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Reservation)4013_storage)": {
+            "label": "mapping(uint256 => struct ERC20Reservable.Reservation)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AddressSet)3340_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3039_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Reservation)4013_storage": {
+            "label": "struct ERC20Reservable.Reservation",
+            "members": [
+              {
+                "label": "_amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_fee",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_recipient",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_executor",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "_expiryBlockNum",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "_status",
+                "type": "t_enum(ReservationStatus)3999",
+                "offset": 0,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(RoleData)179_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)3039_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -57,3 +57,19 @@ function decimals() public pure override returns (uint8) {
         return 6;
     }
 ```
+
+# Basic Sample Hardhat Project
+
+This project demonstrates a basic Hardhat use case. It comes with a sample contract, a test for that contract, a sample script that deploys that contract, and an example of a task implementation, which simply lists the available accounts.
+
+Try running some of the following tasks:
+
+```shell
+npx hardhat accounts
+npx hardhat compile
+npx hardhat clean
+npx hardhat test
+npx hardhat node
+node scripts/sample-script.js
+npx hardhat help
+```

--- a/contractsAddressDeployed.json
+++ b/contractsAddressDeployed.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "ERC20WrapperGluwacoin",
+    "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+    "network": "hardhat",
+    "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploymentDate": "2022-06-21T16:06:59.636Z",
+    "blockHah": "0xc711f22df7724ad762012a12de1f375a86bb4f190547a380147a8842cdbe58da",
+    "blockNumber": 3
+  },
+  {
+    "name": "ProxyAdmin",
+    "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    "network": "hardhat",
+    "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploymentDate": "2022-06-21T16:06:59.644Z",
+    "blockHah": "",
+    "blockNumber": 0
+  },
+  {
+    "name": "ERC20WrapperGluwacoin",
+    "address": "0x000CC169848eC63466A7EfB59e1b925ABAb5F92b",
+    "network": "goerli",
+    "deployer": "0x84eA16043bbFd8916Cb2c764CD858DB0C8b8a6F4",
+    "deploymentDate": "2022-06-21T16:08:46.481Z",
+    "blockHah": "0x466ae48fdd359accf930f486a010b88500003d783a6b058cf5572dffe2790538",
+    "blockNumber": 7098068
+  },
+  {
+    "name": "ProxyAdmin",
+    "address": "0x649F87cac8AD7eA1829c3eB24eFbdB423dC002E6",
+    "network": "goerli",
+    "deployer": "0x84eA16043bbFd8916Cb2c764CD858DB0C8b8a6F4",
+    "deploymentDate": "2022-06-21T16:08:46.680Z",
+    "blockHah": "",
+    "blockNumber": 0
+  }
+]

--- a/contractsAddressDeployedHistory.json
+++ b/contractsAddressDeployedHistory.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "ERC20WrapperGluwacoin",
+    "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+    "network": "hardhat",
+    "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploymentDate": "2022-06-21T15:40:41.259Z",
+    "blockHah": "0xb5c3090cadcaae62766142068d2764ae00fa9ef6cfb85cca748fcef75161f790",
+    "blockNumber": 3
+  },
+  {
+    "name": "ERC20WrapperGluwacoin",
+    "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+    "network": "hardhat",
+    "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploymentDate": "2022-06-21T15:42:17.367Z",
+    "blockHah": "0x8b16db3bd2ace2dc60eba19f1c7ff68ac091109d11bd74606170e84daa212b12",
+    "blockNumber": 3
+  },
+  {
+    "name": "ProxyAdmin",
+    "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    "network": "hardhat",
+    "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploymentDate": "2022-06-21T15:42:17.375Z",
+    "blockHah": "",
+    "blockNumber": 0
+  },
+  {
+    "name": "ERC20WrapperGluwacoin",
+    "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+    "network": "hardhat",
+    "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploymentDate": "2022-06-21T16:06:59.636Z",
+    "blockHah": "0xc711f22df7724ad762012a12de1f375a86bb4f190547a380147a8842cdbe58da",
+    "blockNumber": 3
+  },
+  {
+    "name": "ProxyAdmin",
+    "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    "network": "hardhat",
+    "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploymentDate": "2022-06-21T16:06:59.644Z",
+    "blockHah": "",
+    "blockNumber": 0
+  },
+  {
+    "name": "ERC20WrapperGluwacoin",
+    "address": "0x000CC169848eC63466A7EfB59e1b925ABAb5F92b",
+    "network": "goerli",
+    "deployer": "0x84eA16043bbFd8916Cb2c764CD858DB0C8b8a6F4",
+    "deploymentDate": "2022-06-21T16:08:46.481Z",
+    "blockHah": "0x466ae48fdd359accf930f486a010b88500003d783a6b058cf5572dffe2790538",
+    "blockNumber": 7098068
+  },
+  {
+    "name": "ProxyAdmin",
+    "address": "0x649F87cac8AD7eA1829c3eB24eFbdB423dC002E6",
+    "network": "goerli",
+    "deployer": "0x84eA16043bbFd8916Cb2c764CD858DB0C8b8a6F4",
+    "deploymentDate": "2022-06-21T16:08:46.680Z",
+    "blockHah": "",
+    "blockNumber": 0
+  }
+]

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,74 @@
+require('dotenv').config({path:__dirname+'/.env.development'});
+require("@nomiclabs/hardhat-waffle");
+require("hardhat-awesome-cli");
+require("@nomiclabs/hardhat-etherscan");
+require('@openzeppelin/hardhat-upgrades');
+
+// This is a sample Hardhat task. To learn how to create your own go to
+// https://hardhat.org/guides/create-task.html
+task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
+  const accounts = await hre.ethers.getSigners();
+
+  for (const account of accounts) {
+    console.log(account.address);
+  }
+});
+
+// You need to export an object to set up your config
+// Go to https://hardhat.org/config/ to learn more
+
+/**
+ * @type import('hardhat/config').HardhatUserConfig
+ */
+module.exports = {
+  networks:{
+    hardhat: {
+      // forking: {
+      //   url: process.env.RPC_RINKEBY,
+      //   blockNumber: 10802792
+      // },
+      // allowUnlimitedContractSize: true,
+      gas: 72_000_000,
+      blockGasLimit: 72_000_000,
+      gasPrice: 2000,
+      initialBaseFeePerGas: 1
+    },
+    rinkeby:{
+      url: `${process.env.RPC_RINKEBY}`,
+      chainId: 4,
+      gas: 25000000,
+      gasPrice: 12000000000,
+      accounts: {
+        mnemonic: `${process.env.RINKEBY_MNEMONIC}`,
+        path: "m/44'/60'/0'/0",
+        initialIndex: 0,
+        count: 10,
+        passphrase: ""
+      }
+    },
+    goerli: {
+      url: `${process.env.RPC_GOERLI}`,
+      chainId: 5,
+      gas: 25000000,
+      gasPrice: 12000000000,
+      accounts: [process.env.PRIVATE_KEY_GOERLI]
+    },
+  },
+  etherscan: {
+    // Your API key for Etherscan
+    // Obtain one at https://etherscan.io/
+    apiKey: process.env.ETHERSCAN_API_KEY
+  },
+  solidity: {
+    version: "0.8.6",
+    settings: {
+      optimizer: {
+        runs: 200,
+        enabled: true
+      }
+    }
+  },
+  mocha: {
+    timeout: 20000000
+  },
+};

--- a/migrations/2_deploy_upgradable_ERC20WrapperGluwacoin.js
+++ b/migrations/2_deploy_upgradable_ERC20WrapperGluwacoin.js
@@ -3,7 +3,6 @@ const { deployProxy } = require('@openzeppelin/truffle-upgrades');
 
 const ERC20WrapperGluwacoin = artifacts.require('ERC20WrapperGluwacoin');
 
-
 module.exports = async function (deployer, network) {
     const name = 'USDC Gluwacoin';
     const symbol = 'USDC-G';
@@ -15,11 +14,10 @@ module.exports = async function (deployer, network) {
     switch (network) {
         case "goerli":
             {
-                baseTokenAddress = '0x07865c6E87B9F70255377e024ace6630C1Eaa37F';
+                baseTokenAddress = '0x07865c6E87B9F70255377e024ace6630C1Eaa37F'; // USDC Goerli
                 admin = "0xfd91d059f0d0d5f6adee0f4aa1fdf31da2557bc9";
                 break;
             }
-
         case "rinkeby":
             {
                 baseTokenAddress = '0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b';

--- a/migrations/2_deploy_upgradable_ERC20WrapperGluwacoin.js
+++ b/migrations/2_deploy_upgradable_ERC20WrapperGluwacoin.js
@@ -13,6 +13,13 @@ module.exports = async function (deployer, network) {
     var skip = false;
 
     switch (network) {
+        case "goerli":
+            {
+                baseTokenAddress = '0x07865c6E87B9F70255377e024ace6630C1Eaa37F';
+                admin = "0xfd91d059f0d0d5f6adee0f4aa1fdf31da2557bc9";
+                break;
+            }
+
         case "rinkeby":
             {
                 baseTokenAddress = '0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b';

--- a/migrations/3_upgrade_ERC20WrapperGluwacoin.js
+++ b/migrations/3_upgrade_ERC20WrapperGluwacoin.js
@@ -4,8 +4,7 @@
 const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const New_ERC20WrapperGluwacoin = artifacts.require('ERC20WrapperGluwacoin');
-//const ERC20WrapperGluwacoin = artifacts.require('ERC20WrapperGluwacoin');
-
+const ERC20WrapperGluwacoin = artifacts.require('ERC20WrapperGluwacoin');
 
 module.exports = async function (deployer, network) {
   if (network == 'goerli') {

--- a/migrations/3_upgrade_ERC20WrapperGluwacoin.js
+++ b/migrations/3_upgrade_ERC20WrapperGluwacoin.js
@@ -8,6 +8,9 @@ const New_ERC20WrapperGluwacoin = artifacts.require('ERC20WrapperGluwacoin');
 
 
 module.exports = async function (deployer, network) {
+  if (network == 'goerli') {
+    console.info("adres " + instance.address);
+  }
   if (network == 'rinkeby') {
     const existing_address = "0x0aD1439A0e0bFdcD49939f9722866651a4AA9B3C";
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
+    "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@openzeppelin/contracts": "^4.2.0",
+    "@openzeppelin/hardhat-upgrades": "^1.19.0",
+    "hardhat-awesome-cli": "^0.0.15",
     "truffle": "^5.1.67",
     "truffle-privatekey-provider": "^1.5.0"
   },
@@ -21,12 +24,18 @@
   "homepage": "https://github.com/gluwa/ERC-20-Wrapper-Gluwacoin#readme",
   "devDependencies": {
     "@nomiclabs/buidler": "^1.4.8",
+    "@nomiclabs/hardhat-ethers": "^2.0.0",
+    "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@openzeppelin/contracts-upgradeable": "^4.2.0",
     "@openzeppelin/test-environment": "^0.1.9",
     "@openzeppelin/test-helpers": "^0.5.12",
     "@openzeppelin/truffle-upgrades": "^1.8.0",
     "@truffle/hdwallet-provider": "^1.4.2",
-    "chai": "^4.3.4",
+    "chai": "^4.2.0",
+    "dotenv": "^16.0.1",
+    "ethereum-waffle": "^3.0.0",
+    "ethers": "^5.0.0",
+    "hardhat": "^2.9.9",
     "mocha": "^8.1.2",
     "solidity-coverage": "^0.7.16"
   },

--- a/scripts/deploymentWithProxy.js
+++ b/scripts/deploymentWithProxy.js
@@ -1,0 +1,85 @@
+const hre = require("hardhat");
+
+const NAME_ERC20 = 'USDC Gluwacoin';
+const SYMBOL_ERC20 = 'USDC-G';
+const DECIMALS = 6; 
+let baseTokenAddress;
+let admin;
+let skip = false;
+
+
+async function main() {
+  const [deployer] = await hre.ethers.getSigners();
+
+  switch (hre.network.name) {
+    case "hardhat":
+    {
+      baseTokenAddress = '0x07865c6E87B9F70255377e024ace6630C1Eaa37F'; // USDC Goerli
+      admin = deployer.address;
+      break;
+    }
+    case "goerli":
+    {
+      baseTokenAddress = '0x07865c6E87B9F70255377e024ace6630C1Eaa37F'; // USDC Goerli
+      admin = "0xfd91d059f0d0d5f6adee0f4aa1fdf31da2557bc9";
+      break;
+    }
+    case "rinkeby":
+    {
+      baseTokenAddress = '0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b';
+      admin = "0xfd91d059f0d0d5f6adee0f4aa1fdf31da2557bc9";
+      break;
+    }
+    case "mainnet":
+    {
+      baseTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+      admin = "0x8cDFCaAD5df8A24f983882BaF461F33e1bC24000";
+      break;
+    }
+    default: {
+      skip = true;
+      break;
+    }
+  }
+
+  if (!skip) {
+    // We get the contract to deploy
+    const ERC20WrapperGluwacoin = await hre.ethers.getContractFactory('ERC20WrapperGluwacoin');
+    const eRC20WrapperGluwacoin = await hre.upgrades.deployProxy(ERC20WrapperGluwacoin, [
+        NAME_ERC20, 
+        SYMBOL_ERC20, 
+        DECIMALS,
+        admin,
+        baseTokenAddress
+    ]);
+    const eRC20WrapperGluwacoinTnx = await eRC20WrapperGluwacoin.deployTransaction.wait();
+    hre.addressBook.saveContract(
+        'ERC20WrapperGluwacoin',
+        eRC20WrapperGluwacoin.address,
+        network.name,
+        deployer.address,
+        eRC20WrapperGluwacoinTnx.blockHash,
+        eRC20WrapperGluwacoinTnx.blockNumber
+    );
+
+    await eRC20WrapperGluwacoin.deployed();
+
+    console.log("ERC20WrapperGluwacoin deployed to:", eRC20WrapperGluwacoin.address);
+
+    console.log(' ')
+
+    // Get ProxyAdmin address from .openzeppelin/
+    const ProxyAdmin_Address = await hre.addressBook.retrieveOZAdminProxyContract(network.config.chainId);
+    console.log('Deployed using Proxy Admin contract address: ', ProxyAdmin_Address);
+    addressBook.saveContract('ProxyAdmin', ProxyAdmin_Address, network.name, deployer.address);
+  }
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/ERC20WrapperGluwacoin.erc20.test.js
+++ b/test/ERC20WrapperGluwacoin.erc20.test.js
@@ -194,7 +194,7 @@ describe('ERC20WrapperGluwacoin', function () {
             await this.token.mint(amountHalfAndOne, { from: other });
 
             expect(await this.token.balanceOf(other)).to.be.bignumber.equal(amount.add(amountHalfAndOne));
-            this.token.transfer(other, user1, amountHalfAndOne.sub(fee), fee, nonce, signature, { from: deployer }),
+            await this.token.transfer(other, user1, amountHalfAndOne.sub(fee), fee, nonce, signature, { from: deployer }),
             expect(await this.token.balanceOf(user1)).to.be.bignumber.equal(amountHalfAndOne.sub(fee));
             expect(await this.token.balanceOf(other)).to.be.bignumber.equal(amount);
         });

--- a/test/ERC20WrapperGluwacoin.proxy.test.js
+++ b/test/ERC20WrapperGluwacoin.proxy.test.js
@@ -22,7 +22,7 @@ contract('ERC20WrapperGluwacoin Proxy', accounts => {
         this.token = await deployProxy(
                 ERC20WrapperGluwacoin,
                 [name, symbol, decimals, deployer, baseTokenAddress],
-                { from: deployer, unsafeAllowCustomTypes: true, initializer: 'initialize' }
+                { from: deployer,  initializer: 'initialize' }
             );
     });
 
@@ -35,7 +35,7 @@ contract('ERC20WrapperGluwacoin Proxy', accounts => {
 
     it('retrieve returns a value previously initialized after an upgrade', async function () {
         const newToken = await upgradeProxy(
-            this.token.address, ERC20WrapperGluwacoin, { from: deployer, unsafeAllowCustomTypes: true });
+            this.token.address, ERC20WrapperGluwacoin, { from: deployer });
 
         expect(await newToken.name()).to.equal(name);
         expect(await newToken.symbol()).to.equal(symbol);
@@ -45,7 +45,7 @@ contract('ERC20WrapperGluwacoin Proxy', accounts => {
     
     it('retrieve returns a value after upgrade with ERC20WrapperGluwacoin', async function () {
         const newToken = await upgradeProxy(
-            this.token.address, ERC20WrapperGluwacoinV2, { from: deployer, unsafeAllowCustomTypes: true });
+            this.token.address, ERC20WrapperGluwacoinV2, { from: deployer });
 
         expect(await newToken.UPGRADED_CONTEXT()).to.equal(UPGRADED_CONTEXT);
         expect((await newToken.decimals()).toString()).to.equal(newDecimal.toString());

--- a/test/ERC20WrapperGluwacoin.reserve.test.js
+++ b/test/ERC20WrapperGluwacoin.reserve.test.js
@@ -221,7 +221,7 @@ describe('ERC20WrapperGluwacoin_Reservable', function () {
     
             var signature = sign.signReserve(4, 1, this.token.address, other, other_privateKey, another, executor, reserve_amount, reserve_fee, nonce,expiryBlockNum);
     
-            this.token.reserve(other, another, executor, reserve_amount, reserve_fee, nonce, expiryBlockNum, signature, { from: deployer });
+            await this.token.reserve(other, another, executor, reserve_amount, reserve_fee, nonce, expiryBlockNum, signature, { from: deployer });
     
             var reserve = await this.token.getReservation(other, nonce);
     

--- a/test/ERC20WrapperGluwacoin.wrapper.test.js
+++ b/test/ERC20WrapperGluwacoin.wrapper.test.js
@@ -106,7 +106,7 @@ describe('ERC20WrapperGluwacoin_Wrapper', function () {
             await this.baseToken.increaseAllowance(this.token.address, allowance_amount, { from: other });
             await expectRevert(
                 this.token.mint(mint_amount, { from: minter }),
-                'ERC20: transfer amount exceeds allowance'
+                'ERC20: insufficient allowance'
             );
         });
 
@@ -312,7 +312,7 @@ describe('ERC20WrapperGluwacoin_Wrapper', function () {
             await this.baseToken.increaseAllowance(this.token.address, allowance_amount, { from: other });
             await expectRevert(
                 this.token.methods['mint(address,uint256,uint256,uint256,bytes)'](other, mint_amount, mint_fee, nonce, signature, { from: deployer }),
-                'ERC20: transfer amount exceeds allowance'
+                'ERC20: insufficient allowance'
             );
         });
 

--- a/test/ExampleCoin.proxy.test.js
+++ b/test/ExampleCoin.proxy.test.js
@@ -18,7 +18,7 @@ contract('ExampleCoin Proxy', accounts => {
         this.token = await deployProxy(
                 ExampleCoin,
                 [name, symbol, decimals, baseTokenAddress],
-                { from: deployer, unsafeAllowCustomTypes: true, initializer: 'initialize' }
+                { from: deployer, initializer: 'initialize' }
             );
     });
 
@@ -31,7 +31,7 @@ contract('ExampleCoin Proxy', accounts => {
 
     it('retrieve returns a value previously initialized after an upgrade', async function () {
         const newToken = await upgradeProxy(
-            this.token.address, ExampleCoin, { from: deployer, unsafeAllowCustomTypes: true });
+            this.token.address, ExampleCoin, { from: deployer });
 
         expect(await newToken.name()).to.equal(name);
         expect(await newToken.symbol()).to.equal(symbol);

--- a/test/ExampleCoin.test.js
+++ b/test/ExampleCoin.test.js
@@ -149,7 +149,7 @@ describe('ExampleCoin_Wrapper', function () {
             await this.baseToken.increaseAllowance(this.token.address, allowance_amount, { from: other });
             await expectRevert(
                 this.token.mint(mint_amount, { from: minter }),
-                'ERC20: transfer amount exceeds allowance'
+                'ERC20: insufficient allowance'
             );
         });
 
@@ -355,7 +355,7 @@ describe('ExampleCoin_Wrapper', function () {
             await this.baseToken.increaseAllowance(this.token.address, allowance_amount, { from: other });
             await expectRevert(
                 this.token.methods['mint(address,uint256,uint256,uint256,bytes)'](other, mint_amount, mint_fee, nonce, signature, { from: deployer }),
-                'ERC20: transfer amount exceeds allowance'
+                'ERC20: insufficient allowance'
             );
         });
 
@@ -1322,7 +1322,7 @@ describe('ExampleCoin_Reservable', function () {
     
             var signature = sign.signReserve(4,1,this.token.address, other, other_privateKey, another, executor, reserve_amount, reserve_fee, nonce,expiryBlockNum);
     
-            this.token.reserve(other, another, executor, reserve_amount, reserve_fee, nonce, expiryBlockNum, signature, { from: deployer });
+            await this.token.reserve(other, another, executor, reserve_amount, reserve_fee, nonce, expiryBlockNum, signature, { from: deployer });
     
             var reserve = await this.token.getReservation(other, nonce);
     

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,3 +1,4 @@
+require('dotenv').config({path:__dirname+'/.env.development'});
 /**
  * Use this file to configure your truffle project. It's seeded with some
  * common settings for different networks and features like migrations,
@@ -23,7 +24,7 @@
 //
 // const fs = require('fs');
 // const mnemonic = fs.readFileSync(".secret").toString().trim();
-// const PrivateKeyProvider = require("truffle-privatekey-provider");
+const PrivateKeyProvider = require("truffle-privatekey-provider");
 // const privKeyrinkeby = require("./secret");
 // const INFURA_API_KEY = require("./infuraAPI");
 
@@ -51,13 +52,15 @@ module.exports = {
       network_id: "*",       // Any network (default: none)
     },
     goerli: {
-      provider: () => new PrivateKeyProvider(privKeygoerli, "https://goerli.infura.io/v3/" + INFURA_API_KEY),
+      provider: () => new PrivateKeyProvider(process.env.PRIVATE_KEY_GOERLI, process.env.RPC_GOERLI),
+      gasPrice: 62000000000,
+      gas: 3221975,
       network_id: '5',
     },
-    // rinkeby: {
-    //   provider: () => new PrivateKeyProvider(privKeyrinkeby, "https://rinkeby.infura.io/v3/" + INFURA_API_KEY),
-    //   network_id: '4',
-    // },
+    rinkeby: {
+      provider: () => new PrivateKeyProvider(process.env.PRIVATE_KEY_RINKEBY, process.env.RPC_RINKEBY),
+      network_id: '4',
+    },
     // mainnet: {
     //   provider: () => new PrivateKeyProvider(privKeyrinkeby, "https://mainnet.infura.io/v3/" + INFURA_API_KEY),
     //   gasPrice: 62000000000,

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -46,11 +46,11 @@ module.exports = {
     // tab if you use this network and you must also set the `host`, `port` and `network_id`
     // options below to some value.
     //
-    development: {
-      host: "127.0.0.1",     // Localhost (default: none)
-      port: 8545,            // Standard Ethereum port (default: none)
-      network_id: "*",       // Any network (default: none)
-    },
+    // development: {
+    //   host: "127.0.0.1",     // Localhost (default: none)
+    //   port: 8545,            // Standard Ethereum port (default: none)
+    //   network_id: "*",       // Any network (default: none)
+    // },
     goerli: {
       provider: () => new PrivateKeyProvider(process.env.PRIVATE_KEY_GOERLI, process.env.RPC_GOERLI),
       gasPrice: 62000000000,

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -50,6 +50,10 @@ module.exports = {
       port: 8545,            // Standard Ethereum port (default: none)
       network_id: "*",       // Any network (default: none)
     },
+    goerli: {
+      provider: () => new PrivateKeyProvider(privKeygoerli, "https://goerli.infura.io/v3/" + INFURA_API_KEY),
+      network_id: '5',
+    },
     // rinkeby: {
     //   provider: () => new PrivateKeyProvider(privKeyrinkeby, "https://rinkeby.infura.io/v3/" + INFURA_API_KEY),
     //   network_id: '4',


### PR DESCRIPTION
## Notable changes
- Adding goerli deployment script to truffle migration scripts
- Adding Hardhat and a hardhat proxy deployment script

Each time I try deploying with truffle on a live network I was getting a warning that the provider is not EIP-1193-compliant, and then the script will stay stuck after compilation and never actually deploy or give an error...
So I endup adding hardhat and deploying using hardhat...