### PR TITLE
exclude dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,11 @@
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
+    },
+    {
+      "matchDepTypes": ["dependencies"],
+      "excludeDepNames": ["*"],
+      "automerge": false
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,6 @@
   "version": "1.1.0",
   "description": "",
   "main": "index.js",
-  "dependencies": {
-    "@nomiclabs/hardhat-etherscan": "^3.1.0",
-    "@openzeppelin/contracts": "^4.2.0",
-    "@openzeppelin/hardhat-upgrades": "^1.19.0",
-    "truffle": "^5.1.67",
-    "truffle-privatekey-provider": "^1.5.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gluwa/ERC-20-Wrapper-Gluwacoin.git"
@@ -21,6 +14,13 @@
     "url": "https://github.com/gluwa/ERC-20-Wrapper-Gluwacoin/issues"
   },
   "homepage": "https://github.com/gluwa/ERC-20-Wrapper-Gluwacoin#readme",
+  "dependencies": {
+    "@nomiclabs/hardhat-etherscan": "^3.1.0",
+    "@openzeppelin/contracts": "^4.2.0",
+    "@openzeppelin/hardhat-upgrades": "^1.19.0",
+    "truffle": "^5.1.67",
+    "truffle-privatekey-provider": "^1.5.0"
+  },
   "devDependencies": {
     "@nomiclabs/buidler": "^1.4.8",
     "@nomiclabs/hardhat-ethers": "^2.0.0",


### PR DESCRIPTION
## Exclude dependencies in "dependencies" from getting updated

Also, I believe the issue with PR not getting auto-merge is because they are blocked by branch protection, in this repo (and most of our repo) we require 1 approval, so the only PR that got merged from renovate is one that I had approved.
We don't need to manually merge it, if we just approve it, renovate will merge it, if we approve multiple ones, it will merge 1 then update the branch on the other one and merge them 1 by one automatically.

I don't think there is any way to avoid this, else than modifying the branch protection... 
Maybe this option could work, (I don't have access to the setting on this repo to test it)
![BranchProtectionSetting](https://i.ibb.co/nctGJqD/Screenshot-from-2023-04-27-14-03-00.png)